### PR TITLE
Separate docker pull from docker run for progress reporting

### DIFF
--- a/easyearth/tests/test_docker_pull_separation.py
+++ b/easyearth/tests/test_docker_pull_separation.py
@@ -1,0 +1,214 @@
+"""Tests for the separated docker pull / docker run logic in plugin.py."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch, call, PropertyMock
+
+# Ensure project root is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+# Stub out QGIS / PyQt modules so the plugin can be imported without QGIS
+_qgis_mods = [
+    'qgis', 'qgis.core', 'qgis.gui', 'qgis.utils',
+    'qgis.PyQt', 'qgis.PyQt.QtWidgets', 'qgis.PyQt.QtCore', 'qgis.PyQt.QtGui',
+    'PyQt5', 'PyQt5.QtCore', 'PyQt5.QtGui', 'PyQt5.QtWidgets',
+    'PyQt5.QtNetwork', 'PyQt5.QtXml',
+    'easyearth_plugin.core',
+]
+for _mod in _qgis_mods:
+    sys.modules.setdefault(_mod, MagicMock())
+
+from easyearth_plugin.plugin import EasyEarthPlugin
+
+
+def _make_plugin():
+    """Create a minimally initialised EasyEarthPlugin with mocked QGIS deps."""
+    iface = MagicMock()
+    with patch.object(EasyEarthPlugin, '__init__', lambda self, _iface: None):
+        plugin = EasyEarthPlugin(iface)
+
+    # Set the attributes that docker_pull / docker_run / start_server use
+    plugin.iface = iface
+    plugin.docker_path = 'docker'
+    plugin.docker_hub_image_name = 'maverickmiaow/easyearth'
+    plugin.docker_running = False
+    plugin.base_dir = '/tmp/easyearth_base'
+    plugin.cache_dir = '/tmp/easyearth_cache'
+    plugin.docker_mode_button = MagicMock()
+    plugin.docker_mode_button.isChecked.return_value = True
+    plugin.local_mode_button = MagicMock()
+    plugin.local_mode_button.isChecked.return_value = False
+    return plugin
+
+
+class TestDockerPullCalledBeforeRun(unittest.TestCase):
+    """docker pull must finish successfully before docker run is invoked."""
+
+    @patch('easyearth_plugin.plugin.subprocess.run')
+    def test_pull_called_before_run(self, mock_run):
+        """Verify the ordering: rm -> pull -> run."""
+        plugin = _make_plugin()
+
+        # All subprocess calls succeed
+        mock_run.return_value = MagicMock(returncode=0, stdout='Pulling from ...', stderr='')
+
+        plugin.start_server()
+
+        # Collect the first arg of each subprocess.run call
+        commands = [c[0][0] for c in mock_run.call_args_list]
+
+        # Find the pull and run calls
+        pull_indices = [i for i, cmd in enumerate(commands) if 'pull' in cmd]
+        run_indices = [i for i, cmd in enumerate(commands) if 'run' in cmd]
+
+        self.assertTrue(len(pull_indices) > 0, "docker pull was not called")
+        self.assertTrue(len(run_indices) > 0, "docker run was not called")
+        self.assertLess(pull_indices[0], run_indices[0],
+                        "docker pull must be called before docker run")
+
+
+class TestDockerPullFailure(unittest.TestCase):
+    """When docker pull fails, docker run must NOT be called."""
+
+    @patch('easyearth_plugin.plugin.subprocess.run')
+    def test_run_not_called_when_pull_fails(self, mock_run):
+        plugin = _make_plugin()
+
+        def side_effect(cmd, **kwargs):
+            result = MagicMock()
+            if 'pull' in cmd:
+                result.returncode = 1
+                result.stdout = ''
+                result.stderr = 'Error: pull access denied'
+            else:
+                result.returncode = 0
+                result.stdout = ''
+                result.stderr = ''
+            return result
+
+        mock_run.side_effect = side_effect
+
+        plugin.start_server()
+
+        commands = [c[0][0] for c in mock_run.call_args_list]
+        run_calls = [cmd for cmd in commands if 'run' in cmd]
+        self.assertEqual(len(run_calls), 0,
+                         "docker run should not be called when pull fails")
+
+    @patch('easyearth_plugin.plugin.subprocess.run')
+    def test_critical_message_on_pull_failure(self, mock_run):
+        plugin = _make_plugin()
+
+        def side_effect(cmd, **kwargs):
+            result = MagicMock()
+            if 'pull' in cmd:
+                result.returncode = 1
+                result.stdout = ''
+                result.stderr = 'network error'
+            else:
+                result.returncode = 0
+                result.stdout = ''
+                result.stderr = ''
+            return result
+
+        mock_run.side_effect = side_effect
+
+        plugin.start_server()
+
+        # Gather all pushMessage calls
+        messages = [c[0][0] for c in plugin.iface.messageBar().pushMessage.call_args_list]
+        critical_msgs = [m for m in messages if 'failed' in m.lower() or 'aborting' in m.lower()]
+        self.assertTrue(len(critical_msgs) > 0,
+                        "A critical/failure message should be shown when pull fails")
+
+
+class TestDockerPullImageUpToDate(unittest.TestCase):
+    """When the image is already up to date, an informational message is shown."""
+
+    @patch('easyearth_plugin.plugin.subprocess.run')
+    def test_up_to_date_message(self, mock_run):
+        plugin = _make_plugin()
+
+        def side_effect(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ''
+            if 'pull' in cmd:
+                result.stdout = 'Status: Image is up to date for maverickmiaow/easyearth:latest'
+            else:
+                result.stdout = ''
+            return result
+
+        mock_run.side_effect = side_effect
+
+        plugin.start_server()
+
+        messages = [c[0][0] for c in plugin.iface.messageBar().pushMessage.call_args_list]
+        up_to_date = [m for m in messages if 'up to date' in m.lower()]
+        self.assertTrue(len(up_to_date) > 0,
+                        "An 'up to date' message should be shown when image is current")
+
+
+class TestDockerPullNewImage(unittest.TestCase):
+    """When a new image is downloaded, a success message is shown."""
+
+    @patch('easyearth_plugin.plugin.subprocess.run')
+    def test_new_image_message(self, mock_run):
+        plugin = _make_plugin()
+
+        def side_effect(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ''
+            if 'pull' in cmd:
+                result.stdout = 'Status: Downloaded newer image for maverickmiaow/easyearth:latest'
+            else:
+                result.stdout = ''
+            return result
+
+        mock_run.side_effect = side_effect
+
+        plugin.start_server()
+
+        messages = [c[0][0] for c in plugin.iface.messageBar().pushMessage.call_args_list]
+        download_msgs = [m for m in messages if 'downloaded' in m.lower() or 'new' in m.lower()]
+        self.assertTrue(len(download_msgs) > 0,
+                        "A success message should be shown when a new image is downloaded")
+
+
+class TestDockerPullUsesListArgs(unittest.TestCase):
+    """subprocess calls must use list-based args (no shell=True)."""
+
+    @patch('easyearth_plugin.plugin.subprocess.run')
+    def test_pull_uses_list_args(self, mock_run):
+        plugin = _make_plugin()
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+
+        plugin.docker_pull()
+
+        pull_call = mock_run.call_args_list[0]
+        cmd_arg = pull_call[0][0]
+        self.assertIsInstance(cmd_arg, list,
+                              "docker pull should use a list of args, not a string")
+        # shell=True should NOT be in kwargs
+        self.assertFalse(pull_call[1].get('shell', False),
+                         "docker pull must not use shell=True")
+
+    @patch('easyearth_plugin.plugin.subprocess.run')
+    def test_run_uses_list_args(self, mock_run):
+        plugin = _make_plugin()
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+
+        plugin.docker_run()
+
+        run_call = mock_run.call_args_list[0]
+        cmd_arg = run_call[0][0]
+        self.assertIsInstance(cmd_arg, list,
+                              "docker run should use a list of args, not a string")
+        self.assertFalse(run_call[1].get('shell', False),
+                         "docker run must not use shell=True")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/easyearth_plugin/plugin.py
+++ b/easyearth_plugin/plugin.py
@@ -558,38 +558,90 @@ class EasyEarthPlugin:
         elif mode == 'local':
             self.docker_mode_button.setChecked(False)
 
+    def docker_pull(self):
+        """Pull the latest Docker image, returning the subprocess result.
+
+        Shows progress messages in the QGIS message bar so users know whether
+        a new image is being downloaded or the local copy is already up to date.
+        """
+        self.iface.messageBar().pushMessage('Pulling the latest image from Docker Hub', level=Qgis.Info)
+        QApplication.processEvents()
+
+        pull_result = subprocess.run(
+            [self.docker_path, "pull", self.docker_hub_image_name],
+            capture_output=True, text=True, timeout=1800,
+        )
+
+        if pull_result.returncode != 0:
+            self.iface.messageBar().pushMessage(
+                f"Docker pull failed: {pull_result.stderr.strip()}",
+                level=Qgis.Critical,
+            )
+        elif "Image is up to date" in pull_result.stdout:
+            self.iface.messageBar().pushMessage(
+                "Docker image is already up to date.", level=Qgis.Info,
+            )
+        else:
+            self.iface.messageBar().pushMessage(
+                "New Docker image downloaded successfully.", level=Qgis.Success,
+            )
+        QApplication.processEvents()
+
+        return pull_result
+
+    def docker_run(self):
+        """Start the Docker container after a successful pull.
+
+        Returns the subprocess result of the ``docker run`` command.
+        """
+        self.iface.messageBar().pushMessage('Starting the Docker container', level=Qgis.Info)
+        QApplication.processEvents()
+
+        linux_gpu_flags = ["--runtime", "nvidia"] if platform.system().lower() == "linux" else []
+        gpu_flags = ["--gpus", "all"] if platform.system().lower() != "darwin" else []
+
+        docker_run_cmd = [
+            self.docker_path, "run",
+            *linux_gpu_flags,
+            *gpu_flags,
+            "-d", "--name", "easyearth",
+            "-p", "3781:3781",
+            "-v", f"{self.base_dir}:/usr/src/app/easyearth_base",
+            "-v", f"{self.cache_dir}:/usr/src/app/.cache/models",
+            "-e", f"USER_BASE_DIR={self.base_dir}",
+            "-e", "RUN_MODE=docker",
+            self.docker_hub_image_name,
+        ]
+        result = subprocess.run(docker_run_cmd, capture_output=True, text=True, timeout=1800)
+        self.iface.messageBar().pushMessage(f"Starting server...\nRunning command: {result}", level=Qgis.Info)
+
+        if result.returncode == 0:
+            self.docker_running = True
+            self.iface.messageBar().pushMessage("Docker container started successfully.", level=Qgis.Success)
+
+        return result
+
     def start_server(self):
         if self.docker_mode_button.isChecked():
             self.iface.messageBar().pushMessage('Removing the docker container if it already exists', level=Qgis.Info)
             QApplication.processEvents()
-            subprocess.run(f"{self.docker_path} rm -f easyearth 2>/dev/null || true", capture_output=True, text=True, shell=True)  # removes the container if it already exists
-            
-            self.iface.messageBar().pushMessage('Pulling the latest image from Docker Hub', level=Qgis.Info)
-            QApplication.processEvents()
-            warning_box = QMessageBox()
-            warning_box.setIcon(QMessageBox.Warning)
-            warning_box.setWindowTitle("Update Docker Image")
-            warning_box.setTextFormat(Qt.RichText)
-            warning_box.setText("Downloading the latest Docker image from Docker Hub.&nbsp;This may take a while.&nbsp;Please wait...")
-            warning_box.exec_()
-            subprocess.run(f"{self.docker_path} pull {self.docker_hub_image_name}", capture_output=True, text=True, shell=True)  # removes the container if it already exists
-            
-            self.iface.messageBar().pushMessage('Starting the Docker container', level=Qgis.Info)
-            QApplication.processEvents()
-            linux_gpu_flags = " --runtime nvidia" if platform.system().lower() == "linux" else ""  # adds GPU support if available and on Linux
-            gpu_flags = " --gpus all" if platform.system().lower() != "darwin" else ""  # adds GPU support if available and not on macOS
-            docker_run_cmd = (f"{self.docker_path} run{linux_gpu_flags}{gpu_flags} -d --name easyearth -p 3781:3781 " # runs the container in detached mode and maps port 3781
-                              f"-v \"{self.base_dir}\":/usr/src/app/easyearth_base " # mounts the base directory in the container
-                              f"-v \"{self.cache_dir}\":/usr/src/app/.cache/models " # mounts the cache directory in the container
-                              f"-e USER_BASE_DIR=\"{self.base_dir}\" " # sets an environment variable in the container containing the user's base directory
-                              f"-e RUN_MODE=docker " # sets the run mode to docker
-                              f"{self.docker_hub_image_name}")
-            result = subprocess.run(docker_run_cmd, capture_output=True, text=True, shell=True, timeout=1800)
-            self.iface.messageBar().pushMessage(f"Starting server...\nRunning command: {result}", level=Qgis.Info)
+            subprocess.run(
+                [self.docker_path, "rm", "-f", "easyearth"],
+                capture_output=True, text=True,
+            )
 
-            if result.returncode == 0:
-                self.docker_running = True
-                self.iface.messageBar().pushMessage("Docker container started successfully.", level=Qgis.Success)
+            # Pull image first so we can report progress
+            pull_result = self.docker_pull()
+            if pull_result.returncode != 0:
+                self.iface.messageBar().pushMessage(
+                    "Aborting: Docker pull failed. Please check your network connection.",
+                    level=Qgis.Critical,
+                )
+                QApplication.processEvents()
+                return
+
+            # Run the container only after a successful pull
+            self.docker_run()
 
         if self.local_mode_button.isChecked():
             # Download server code
@@ -658,7 +710,8 @@ class EasyEarthPlugin:
 
     def stop_server(self):
         if self.docker_mode_button.isChecked():
-            result = subprocess.run(f"{self.docker_path} stop easyearth && {self.docker_path} rm easyearth", capture_output=True, text=True, shell=True)
+            subprocess.run([self.docker_path, "stop", "easyearth"], capture_output=True, text=True)
+            result = subprocess.run([self.docker_path, "rm", "easyearth"], capture_output=True, text=True)
             self.docker_hub_process = None
             self.docker_running = False
         else:


### PR DESCRIPTION
## Summary
- Splits the docker startup logic in `plugin.py` into dedicated `docker_pull()` and `docker_run()` methods so the plugin can report progress to users via the QGIS message bar
- Checks pull result before proceeding to run -- if pull fails, the container is not started and a critical message is shown
- Shows distinct messages for "image is up to date" vs "new image downloaded"
- Converts all docker subprocess calls from `shell=True` with f-strings to list-based args for security
- Adds 7 unit tests covering ordering, failure handling, messaging, and arg safety

Closes #102

## Test plan
- [x] Run `python easyearth/tests/test_docker_pull_separation.py -v` -- all 7 tests pass
- [ ] Manual test: start server in Docker mode with image already cached (expect "up to date" message)
- [ ] Manual test: start server with a new image available (expect "downloaded" message)
- [ ] Manual test: start server with no network (expect pull failure message, no container started)

🤖 Generated with [Claude Code](https://claude.com/claude-code)